### PR TITLE
Reduce frequency of scheduled job to once per hour to try to avoid cancellations

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -3,7 +3,10 @@ permissions:
   contents: write
 on:
   schedule:
-    - cron: "*/15 * * * *"
+    # Run once per hour, at an arbitrary non-round-number minute to try to
+    # dodge the high load on GitHub Actions that happens at the beginning of
+    # each hour and leads to jobs being delayed.
+    - cron: "41 * * * *"
 concurrency:
   group: ${{ github.workflow }}
 jobs:


### PR DESCRIPTION
Currently, during the main stage ("SCENARIO 2") of the build, `buildAndRelease.js` takes significantly longer to run (almost an hour) than the time between scheduled workflow executions (15 minutes) so some scheduled executions get cancelled, which triggers notifications to me and possibly other people in the nice-registry org.

In the interests of not immediately annoying the nice people who've just added me to their org, I'm going to immediately turn the workflow frequency down to avoid this happening.

(Remark: it looks to me like there's no way to configure your GitHub notification settings to notify about failed workflows but _not_ about auto-cancelled scheduled workflows, which doesn't seem like great design.)