### PR TITLE
Don't clobber user's config (affecting their other work) if they run the script locally

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_PUBLISH_TOKEN}

--- a/buildAndRelease.js
+++ b/buildAndRelease.js
@@ -174,12 +174,8 @@ if (state.published) {
 // SCENARIO 4: We have completed the build process but not yet published it to
 //             npm; it's time to publish.
 if (fs.existsSync(pkg.main)) {
-  // Oddly, npm's CLI doesn't seem to have a way to pass an auth token to it
-  // without writing anything to a config file. So we do that.
-  await promisify(execFile)(
-    'npm',
-    ['config', 'set', '//registry.npmjs.org/:_authToken=${NPM_PUBLISH_TOKEN}']
-  );
+  // (NPM_PUBLISH_TOKEN is referenced by our .npmrc. As best I can tell, having
+  // a config file is *necessary* to use an auth token with npm, oddly enough.)
   if (!process.env.NPM_PUBLISH_TOKEN) {
     console.error(
       'No NPM_PUBLISH_TOKEN set. For runs in GitHub Actions, this should be ' +


### PR DESCRIPTION
I was trying to work on an unrelated package using Yarn 1 today and got this error:

> error Error: Failed to replace env in config: ${NPM_PUBLISH_TOKEN}

because the `config set` call in `buildAndRelease.js` had of course modified my per-user config in `~/.npmrc`. It'd be nice to be able to run the script locally _without_ screwing up config for things other than this package. I think this change makes that happen; I'm gonna merge it and see if anything breaks. (Worst case is the `npm publish` call will fail on the next build and I'll have to fix it.)