### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The https://npmjs.org/package/download-counts package, updated with a new versio
 To check monthly download counts of individual packages:
 
 ```
-> const downloadCounts = require('@explodingcabbage/package-counts')
+> const downloadCounts = require('download-counts')
 undefined
 > downloadCounts.lodash
 310086369


### PR DESCRIPTION
Update README to refer to correct package name, not old `@explodingcabbage/` scoped one.

(I actually did this already over at https://github.com/ExplodingCabbage/download-counts/commits/master/ but evidently screwed up and didn't include it in https://github.com/nice-registry/download-counts/pull/3)