### PR TITLE
Try to fix 429 (rate limiting) error responses

### DIFF
--- a/buildAndRelease.js
+++ b/buildAndRelease.js
@@ -241,7 +241,7 @@ const counts = {};
 //
 // We:
 // * Run this many "threads" sending requests...
-const MAX_SIMULTANEOUS_REQUESTS = 16;
+const MAX_SIMULTANEOUS_REQUESTS = 4;
 // * ... and have each thread wait at least this many ms after starting one
 // request before it starts the next
 const MIN_REQUEST_INTERVAL_MS = 600


### PR DESCRIPTION
We're seeing multiple workflows just getting timeout responses over and over forever - e.g. https://github.com/nice-registry/download-counts/actions/runs/19386625762/job/55475252172 and https://github.com/nice-registry/download-counts/actions/runs/19394681317/job/55493866375

They seem to be the result of a new, Cloudflare-based rate limiter that is MUCH stricter and does not emit a Retry-After header. Running the old script locally *instantly* resulted in getting my IP temporarily banned from the API, as soon as the first batch of 20 parallel requests was sent off.

Let's see if this will at least let the script run without blowing up (although, yikes, these parameters are going to mean much longer builds).