### PR TITLE
Reduce rate of requests again, but slightly less than before

### DIFF
--- a/buildAndRelease.js
+++ b/buildAndRelease.js
@@ -261,7 +261,7 @@ const counts = {};
 const MAX_SIMULTANEOUS_REQUESTS = 2;
 // * ... and have each thread wait at least this many ms after starting one
 // request before it starts the next
-const MIN_REQUEST_INTERVAL_MS = 3000;
+const MIN_REQUEST_INTERVAL_MS = 3600;
 // Just in case, though, we ALSO pause if we get a 429 response and wait for
 // the number of seconds indicated in the Retry-After header. If that happens,
 // the timestamp to wait until gets stored in this variable and respected by


### PR DESCRIPTION
Per https://github.com/nice-registry/download-counts/actions/runs/26031868012/job/76519628696, my change in https://github.com/nice-registry/download-counts/pull/10 was too aggressive.

Maybe we can still go 11% faster than we used to without getting rate-limited, though? Let's see.